### PR TITLE
setup: pnpm monorepo & prettier package 구현 및 분리

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,35 @@
+name: cd
+
+on:
+  push:
+    branches:
+      - 'main'
+
+env:
+  NODE_VERSION: '16.x'
+  NPM_REGISTRY_URL: 'https://npm.pkg.github.com/'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: ${{ env.NPM_REGISTRY_URL }}
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: true
+
+      - name: 🛫 Deploy
+        run: pnpm run deploy
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+.vscode

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@grownbetter:resistry=https://npm.pkg.github.com/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+"./packages/prettier-config-grownbetter/prettierrc"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
-# grownbetter-config-kit
+# grownbetter-config-kit [![CD][cd-image]][cd-url]
 
-그로우엔배터의 컨벤션 규칙을 정의한 Linter/Formatter Configuration의 모음입니다.
+[cd-image]: https://github.com/Grownbetter/grownbetter-config-kit/actions/workflows/cd.yaml/badge.svg?branch=main
+[cd-url]: https://github.com/Grownbetter/grownbetter-config-kit/actions/workflows/cd.yaml
+
+그로우앤베터의 컨벤션 규칙을 정의한 Linter/Formatter Configuration의 모음입니다.
+
+- [@grownbetter/prettier-config-grownbetter](packages/prettier-config-grownbetter)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "grownbetter-config-kit",
+  "version": "0.0.1",
+  "author": "grownbetter",
+  "description": "🗂️ ESLint, Prettier, Stylelint configuration for grownbetter",
+  "keywords": [
+    "eslint",
+    "eslintconfig",
+    "prettier",
+    "stylelint",
+    "config",
+    "javascript",
+    "typescript",
+    "grownbetter"
+  ],
+  "license": "MIT",
+  "engines": {
+    "pnpm": ">= 8"
+  },
+  "scripts": {
+    "deploy:prettier": "pnpm -F @grownbetter/prettier-config-grownbetter run deploy",
+    "deploy": "pnpm run deploy:prettier"
+  }
+}

--- a/packages/prettier-config-grownbetter/README.md
+++ b/packages/prettier-config-grownbetter/README.md
@@ -1,0 +1,34 @@
+# @grownbetter/prettier-config-grownbetter
+
+## Installation
+
+```bash
+npm install @grownbetter/prettier-config-grownbetter prettier --save-dev
+```
+
+## Usage
+
+`package.json` 파일의 `scripts` 속성에 다음을 추가해주세요.
+
+```json
+{
+  "scripts": {
+    "prettier": "prettier . --check",
+    "prettier:fix": "prettier . --write"
+  }
+}
+```
+
+`.prettierrc` 파일을 생성하고 다음을 추가해주세요.
+
+```js
+'@grownbetter/prettier-config-grownbetter';
+```
+
+또는 `package.json` 파일에 다음을 추가해주세요.
+
+```json
+{
+  "prettier": "@grownbetter/prettier-config-grownbetter"
+}
+```

--- a/packages/prettier-config-grownbetter/package.json
+++ b/packages/prettier-config-grownbetter/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@grownbetter/prettier-config-grownbetter",
+  "version": "0.0.1",
+  "description": "grownbetter's Prettier config",
+  "license": "MIT",
+  "main": "prettierrc.js",
+  "files": [
+    "*.js"
+  ],
+  "homepage": "https://github.com/grownbetter/prettier-config-grownbetter",
+  "bugs": {
+    "url": "https://github.com/grownbetter/prettier-config-grownbetter/issues"
+  },
+  "keywords": [
+    "prettier",
+    "javascript",
+    "typescript",
+    "convention"
+  ],
+  "repository": {
+    "type": "git",
+    "directory": "packages/prettier-config-grownbetter"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "deploy": "npm publish --access=public",
+    "prettier": "prettier '**/*' --check",
+    "prettier:fix": "prettier '**/*' --write"
+  },
+  "devDependencies": {
+    "prettier": "^3.0.3"
+  },
+  "peerDependencies": {
+    "prettier": "^2.0.0 || ^3.0.0"
+  }
+}

--- a/packages/prettier-config-grownbetter/prettierrc.js
+++ b/packages/prettier-config-grownbetter/prettierrc.js
@@ -1,0 +1,10 @@
+/** @type {import('prettier'.Options)} */
+module.exports = {
+  useTabs: false,
+  semi: true,
+  singleQuote: true,
+  printWidth: 80,
+  tabWidth: 2,
+  trailingComma: "all",
+  endOfLine: "lf",
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  packages/@grownbetter/prettier-config-grownbetter:
+    devDependencies:
+      prettier:
+        specifier: ^3.0.3
+        version: 3.0.3
+
+packages:
+
+  /prettier@3.0.3:
+    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"


### PR DESCRIPTION
## 작업 사항

- pnpm workspace 구현
- prettier 패키지 분리
- npm 배포 환경 구성
- prettier 규칙 작성
- cd workflows 구현 (추후 정책에 따라 변경 예정)

## 확인이 필요한 사항
- github organization token이 별도로 관리 되고 있나요? (npm github registry에 배포하기 위함)
- prettier 이후 eslint 작업 예정입니다.